### PR TITLE
Fix demo of ssh remediation

### DIFF
--- a/arc-playground/demo-of-ssh-autoremediation-policy.sh
+++ b/arc-playground/demo-of-ssh-autoremediation-policy.sh
@@ -26,7 +26,7 @@ SSH_KEY=$(cat ~/.ssh/id_rsa.pub)
 USERNAME=$(whoami)
 
 # 6. Install SSH extension for manual inspection
-az vm extension set --resource-group "${RG}" --vm-name "${VM}" --name VMAccessForLinux --publisher Microsoft.OSTCExtensions --version 1.4 --protected-settings '{"username": "demouser", "ssh_key":"'${SSH_KEY}'"}'
+az vm extension set --resource-group "${RG}" --vm-name "${VM}" --name VMAccessForLinux --publisher Microsoft.OSTCExtensions --version 1.4 --protected-settings '{"username": "demouser", "ssh_key":"'"${SSH_KEY}"'"}'
 
 # 7. Log into the VM
 az ssh vm --local-user "${USERNAME}" --name "${VM}" --resource-group "${RG}" -- -o StrictHostKeyChecking=accept-new -i ~/.ssh/id_rsa


### PR DESCRIPTION
Due to incorrect quoting of shell, json this script will fail on step 6

\# 6. Install SSH extension for manual inspection
az vm extension set --resource-group "${RG}" --vm-name "${VM}" --name VMAccessForLinux --publisher Microsoft.OSTCExtensions --version 1.4 --protected-settings '{"username": "demouser", "ssh_key":"'"${SSH_KEY}"'"}'


SSH_KEY is variable that contains space so allow correct expansion use "${SSH_KEY}"
Next:
json needs it's keys and values put into quotes therefore we need extra quotes around $SSH_KEYS but then whole json string is inside single quotes so we must end the json string single quotes, and add prefix/suffix of double quotes so that:
    '"ssh_key":"'"${SSH_KEYS}"'"'

will be expanded to :
    "ssh_key": "abcde"

note that lack of spacing is neccesary otherwise shell will add extra space

Signed-off-by: Krzysztof Kanas <kkanas@microsoft.com>

gh

## Description

*Describe your changes in as much detail as possible. Provide a link/reference to the issue solved with this request if any.*

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] All unit tests are passing.
- [x] I have merged the latest `main` branch prior to this PR submission.
- [x] I submitted this PR against the `main` branch.