### PR TITLE
Fix error handling for uncomon case when lscpu is not present 

### DIFF
--- a/src/common/commonutils/DeviceInfoUtils.c
+++ b/src/common/commonutils/DeviceInfoUtils.c
@@ -328,7 +328,7 @@ bool CheckCpuFlagSupported(const char* cpuFlag, char** reason, void* log)
     bool result = false;
     char* cpuFlags = GetCpuFlags(log);
 
-    if ((NULL != cpuFlag) && (NULL != strstr(cpuFlags, cpuFlag)))
+    if ((NULL != cpuFlags) && (NULL != strstr(cpuFlags, cpuFlag)))
     {
         OsConfigLogInfo(log, "CPU flag '%s' is supported", cpuFlag);
         OsConfigCaptureSuccessReason(reason, "The device's CPU supports '%s'", cpuFlag);


### PR DESCRIPTION
When lscpu is not present, or not in path the code GetCpuFlags can return null. There is a typo which check cpuFlag inste cpuFlags

## Description

*Describe your changes in as much detail as possible. Provide a link/reference to the issue solved with this request if any.*

## Checklist

- [ ] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [ ] I added unit-tests to validate my changes. All unit tests are passing.
- [ ] I have merged the latest `main` branch prior to this PR submission.
- [ ] I submitted this PR against the `main` branch.